### PR TITLE
Copy collect field

### DIFF
--- a/packages/botkit-plugin-cms/package.json
+++ b/packages/botkit-plugin-cms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@optania/botkit-plugin-cms",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Extend Botkit with access to botkit-cms",
   "main": "./lib/index.js",
   "typings": "./lib/index.d.ts",

--- a/packages/botkit-plugin-cms/src/plugin-core.ts
+++ b/packages/botkit-plugin-cms/src/plugin-core.ts
@@ -75,6 +75,9 @@ export abstract class CmsPluginCore {
             delete (line.meta);
         }
 
+        // Copy collect method array
+        line.channelData.collect = line.collect;
+
         return line;
     }
 


### PR DESCRIPTION
Ajout du champ collect provenant du format de botkit-cms afin de l'avoir du côté de l'objet Activity Botbuilder et savoir si des informations sont attendu de la part de l'utilisateur.